### PR TITLE
Add ability to specify custom content type.

### DIFF
--- a/lib/jimson/client.rb
+++ b/lib/jimson/client.rb
@@ -17,7 +17,7 @@ module Jimson
       URI.parse(@url) # for the sake of validating the url
       @batch = []
       @opts = opts
-      @opts[:content_type] = 'application/json'
+      @opts[:content_type] ||= 'application/json'
     end
 
     def process_call(sym, args)
@@ -91,7 +91,7 @@ module Jimson
       return false if data.has_key?('error') && data.has_key?('result')
 
       if data.has_key?('error')
-        if !data['error'].is_a?(Hash) || !data['error'].has_key?('code') || !data['error'].has_key?('message') 
+        if !data['error'].is_a?(Hash) || !data['error'].has_key?('code') || !data['error'].has_key?('message')
           return false
         end
 
@@ -101,7 +101,7 @@ module Jimson
       end
 
       return true
-      
+
       rescue
         return false
     end
@@ -114,7 +114,7 @@ module Jimson
     end
 
     def send_batch
-      batch = @batch.map(&:first) # get the requests 
+      batch = @batch.map(&:first) # get the requests
       response = send_batch_request(batch)
 
       begin
@@ -130,14 +130,14 @@ module Jimson
   end
 
   class BatchClient < BlankSlate
-    
+
     def initialize(helper)
       @helper = helper
     end
 
     def method_missing(sym, *args, &block)
       request = Jimson::Request.new(sym.to_s, args)
-      @helper.push_batch_request(request) 
+      @helper.push_batch_request(request)
     end
 
   end
@@ -146,7 +146,7 @@ module Jimson
     reveal :instance_variable_get
     reveal :inspect
     reveal :to_s
-    
+
     def self.batch(client)
       helper = client.instance_variable_get(:@helper)
       batch_client = BatchClient.new(helper)
@@ -163,7 +163,7 @@ module Jimson
     end
 
     def [](method, *args)
-      @helper.process_call(method, args.flatten) 
+      @helper.process_call(method, args.flatten)
     end
 
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -73,6 +73,14 @@ module Jimson
           client = Client.new(SPEC_URL, :timeout => 10000)
           client.foo(1,2,3).should == 42
         end
+
+        it "sends a valid JSON-RPC request with custom content_type" do
+          response = MultiJson.encode(BOILERPLATE.merge({'result' => 42}))
+          RestClient.should_receive(:post).with(SPEC_URL, @expected, {:content_type => 'application/json-rpc', :timeout => 10000}).and_return(@resp_mock)
+          @resp_mock.should_receive(:body).at_least(:once).and_return(response)
+          client = Client.new(SPEC_URL, :timeout => 10000, :content_type => 'application/json-rpc')
+          client.foo(1,2,3).should == 42
+        end
       end
     end
 
@@ -82,7 +90,7 @@ module Jimson
           {"jsonrpc" => "2.0", "method" => "sum", "params" => [1,2,4], "id" => "1"},
           {"jsonrpc" => "2.0", "method" => "subtract", "params" => [42,23], "id" => "2"},
           {"jsonrpc" => "2.0", "method" => "foo_get", "params" => [{"name" => "myself"}], "id" => "5"},
-          {"jsonrpc" => "2.0", "method" => "get_data", "id" => "9"} 
+          {"jsonrpc" => "2.0", "method" => "get_data", "id" => "9"}
         ])
 
         response = MultiJson.encode([


### PR DESCRIPTION
Some services use other content types than 'application/json', for example, 'application/json-rpc'. JSON RPC 2.0 spec does not stand which type should application use, so ability to customize it would be useful.
