### PR TITLE
Fix json variable name on invalid json response

### DIFF
--- a/lib/jimson/client.rb
+++ b/lib/jimson/client.rb
@@ -122,7 +122,7 @@ module Jimson
       begin
         responses = MultiJson.decode(response)
       rescue
-        raise Client::Error::InvalidJSON.new(json)
+        raise Client::Error::InvalidJSON.new(response)
       end
 
       process_batch_response(responses)


### PR DESCRIPTION
Changing `json`, which is undefined, to `response` in `send_batch`.